### PR TITLE
Add: Gemfile.lockのPLATFRORMを追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,11 +94,15 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.0)
     minitest (5.15.0)
     msgpack (1.4.5)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     nio4r (2.5.8)
+    nokogiri (1.13.3)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.13.3-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.3-x86_64-linux)
@@ -217,6 +221,8 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
+  aarch64-linux
+  arm64-darwin-20
   ruby
   x86_64-darwin-21
   x86_64-linux


### PR DESCRIPTION
## 概要

PCのCPU環境の違い（M1 か Intel か）によるコンフリクト解消のため、
以下の方法で、Gemfile.lock を新規に作成しました。

① M1 で bundle install する
②↑で生成された Gemfile.lock に以下の記述を追加
　aarch64-linux
　arm64-darwin-20
③↑のGemfile.lock を Intel PCに反映させ、無事に動けばOK！

## 確認方法

- [ ] 確認用にブランチを切る
- [ ] Gemfile.lock を書き換えて、bundle install する