### PR TITLE
40_403ページのレイアウト修正

### DIFF
--- a/public/403.html
+++ b/public/403.html
@@ -1,5 +1,16 @@
 <!DOCTYPE html>
-<div id="errors">
-  <h1>403 Forbidden</h1>
-  <p>指定されたページを表示する権限がありません</p>
-</div>
+<header>
+  <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
+</header>
+<body>
+  <div class="bg-white py-6 sm:py-8 lg:py-12">
+    <div class="max-w-screen-2xl px-4 md:px-8 mx-auto">
+      <div class="flex flex-col items-center">
+        <p class="text-indigo-500 text-sm md:text-base font-semibold uppercase mb-4">That's a 403</p>
+        <h1 class="text-gray-800 text-2xl md:text-3xl font-bold text-center mb-2">ForBidden!</h1>
+        <p class="max-w-screen-md text-gray-500 md:text-lg text-center mb-12">権限がありません</p>
+        <a href="/" class="text-white bg-indigo-400 hover:bg-indigo-500 font-medium rounded-lg text-lg px-5 py-2.5 text-center mr-2 mb-2">トップページへ</a>
+      </div>
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
## 概要
権限エラーで表示する403画面のレイアウトを修正いたしました。
5c966e56a06cb039783bb230e79c183568f0bd95 403ページの修正

## 確認方法
以下をご確認ください。
- ゲストログインご後、`/profile`、`/admin`に遷移した際に、以下のページが表示されること <img width="998" alt="スクリーンショット 2022-05-15 18 22 04" src="https://user-images.githubusercontent.com/93305003/168465947-0ea2431f-3823-4604-bc97-ef147f94576f.png">
- トップページへのボタンでトップページへ戻ること

## チェックリスト
- [x] Lint のチェックをパスした

close #80 