### PR TITLE
43_fix: 線の太さを5からスタートするように修正

### DIFF
--- a/app/javascript/packs/pictures/new.js
+++ b/app/javascript/packs/pictures/new.js
@@ -26,6 +26,8 @@ document.addEventListener('DOMContentLoaded',()=> {
 
   setBgColor();
 
+  ctx.lineWidth = 5;
+
   var myStorage = localStorage;
   window.onload = initLocalStorage();
 


### PR DESCRIPTION
## 概要

お絵描きページの太さ変更機能で、アクセス直後に太さの画面表示は５に対し、
実際は１の太さで引かれてしまうバグを修正しました。

発生していたバグ
[![Image from Gyazo](https://i.gyazo.com/0bdc58ec48e81b3b3a20c794e2e13745.gif)](https://gyazo.com/0bdc58ec48e81b3b3a20c794e2e13745)

## 確認方法

お絵描きページにアクセス直後、線の太さが５で引けるか確認する。

## 影響範囲

特になし

## コメント

他の機能を実装している時にたまたま見つけたので、修正しました！
確認お願いします。
